### PR TITLE
删除模板中间件重复初始化代码

### DIFF
--- a/template/router.template
+++ b/template/router.template
@@ -34,9 +34,6 @@ func InitRouter() {
 		os.Exit(-1)
 	}
 
-	r.Use(common.Sentinel()).
-		Use(common.RequestId(pkg.TrafficKey))
-	common.InitMiddleware(r)
 	// the jwt middleware
 	authMiddleware, err := common.AuthInit()
 	if err != nil {


### PR DESCRIPTION
go-admin app -n 创建目录，重复初始化会导致获取不到body中的参数